### PR TITLE
[FIX] Fix docker-compose mappings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - 8000:80
     volumes:
       - ./:/var/www
-      - ./docker-compose/nginx:/etc/nginx/conf.d
+      - ./docker-compose/nginx/:/etc/nginx/conf.d
     networks:
       - api
 

--- a/docker-compose/nginx/api.conf
+++ b/docker-compose/nginx/api.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    index server.php index.html;
+    index index.php index.html;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
     root /var/www/public;
@@ -14,7 +14,7 @@ server {
         fastcgi_param PATH_INFO $fastcgi_path_info;
     }
     location / {
-        try_files $uri $uri/ /server.php?$query_string;
+        try_files $uri $uri/ /index.php?$query_string;
         gzip_static on;
     }
 }


### PR DESCRIPTION
Fixing:

1. Wrong `api.conf` file;
2. Wrong path mapping to `volumes` at `nginx` service.